### PR TITLE
Update github.com/bufbuild/buf/releases from v0.26.0 to v0.27.1

### DIFF
--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.11 AS buf
 
-ARG BUF_VERSION=v0.26.0
-ARG BUF_CHECKSUM=6bab7d8de7c39558a955c6dc2d19331fb5d630eff9b0f5a4de5e77548db20331
+ARG BUF_VERSION=v0.27.1
+ARG BUF_CHECKSUM=2940c9826448c143d62c66264d4e111e4f74a0d9292b15ba919916fe3827a3fc
 
 ARG BUFF_URL=https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64
 RUN apk --no-cache add --virtual .build curl \


### PR DESCRIPTION
Here is github.com/bufbuild/buf/releases v0.27.1, I hope it works.

<!--::action-update-go::
{"signed":{"name":"buf","updates":[{"path":"github.com/bufbuild/buf/releases","previous":"v0.26.0","next":"v0.27.1"}]},"signature":"Detgti/flxUfeCf8F2Ac6i5nMI/vWrpig/TRle7l1LTrt1BBfYgm0Hmi/7JdaxC+vn0nDLMbgPV/UV5yLnH2EQ=="}
-->