### PR TITLE
Update github.com/bufbuild/buf/releases from v0.28.0 to v0.29.0

### DIFF
--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.11 AS buf
 
-ARG BUF_VERSION=v0.28.0
-ARG BUF_CHECKSUM=10e9ded3441e3a8d884f5a89b7f830f39cd6d832540638db3df9eeabe5516065
+ARG BUF_VERSION=v0.29.0
+ARG BUF_CHECKSUM=02165da6c0955cbe6c786f492d99736b807318fcbd41b21cd2dd80f0c4355487
 
 ARG BUFF_URL=https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64
 RUN apk --no-cache add --virtual .build curl \


### PR DESCRIPTION
Here is github.com/bufbuild/buf/releases v0.29.0, I hope it works.

<!--::action-update-go::
{"signed":{"name":"buf","updates":[{"path":"github.com/bufbuild/buf/releases","previous":"v0.28.0","next":"v0.29.0"}]},"signature":"TGGOhZPFwvlv7jJbJvP2B4ufwvbV9USpzYPb5hyG1Dd0xOnOEO2iRtChDdt7ES9+lxHdPBfN6VU7HEsv1VKrIw=="}
-->