### PR TITLE
Update github.com/bufbuild/buf/releases from v0.29.0 to v0.30.0

### DIFF
--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.11 AS buf
 
-ARG BUF_VERSION=v0.29.0
-ARG BUF_CHECKSUM=02165da6c0955cbe6c786f492d99736b807318fcbd41b21cd2dd80f0c4355487
+ARG BUF_VERSION=v0.30.0
+ARG BUF_CHECKSUM=a387bcee312c5d2d77f4c7adb1f3dfe468ddc032c44e017384790824b101bcea
 
 ARG BUFF_URL=https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64
 RUN apk --no-cache add --virtual .build curl \


### PR DESCRIPTION
Here is github.com/bufbuild/buf/releases v0.30.0, I hope it works.

<!--::action-update-go::
{"signed":{"name":"buf","updates":[{"path":"github.com/bufbuild/buf/releases","previous":"v0.29.0","next":"v0.30.0"}]},"signature":"Ytzb1xQSgbgE6huMVkAKlF/2c5zptbvz+aDXVD6OiVt1m0Q8QI1KIFVD7X7z01PTRQ8gysgaJQsAiWtoQg1YFA=="}
-->