### PR TITLE
Update github.com/bufbuild/buf/releases from v0.30.1 to v0.31.0

### DIFF
--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.11 AS buf
 
-ARG BUF_VERSION=v0.30.1
-ARG BUF_CHECKSUM=1b3a68af3902cae1223a1d5272c1e72b3d12f05cc34f0f8ad0c35e771af40cde
+ARG BUF_VERSION=v0.31.0
+ARG BUF_CHECKSUM=2f1c68c349a78fd4fe29220c81f6c653e841a2bf36aa58143562f055589a4450
 
 ARG BUFF_URL=https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64
 RUN apk --no-cache add --virtual .build curl \


### PR DESCRIPTION
Here is github.com/bufbuild/buf/releases v0.31.0, I hope it works.

<!--::action-update-go::
{"signed":{"name":"buf","updates":[{"path":"github.com/bufbuild/buf/releases","previous":"v0.30.1","next":"v0.31.0"}]},"signature":"o947j7WOSRBJK6oCDxcUb1ThYdX/LoUT777hfPULZ4dAVpPfi6FtVlIIDyfB+d8ocr5XScUXx2X3Z/UKTKaJcw=="}
-->