### PR TITLE
Update github.com/bufbuild/buf/releases from v0.31.0 to v0.31.1

### DIFF
--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.11 AS buf
 
-ARG BUF_VERSION=v0.31.0
-ARG BUF_CHECKSUM=2f1c68c349a78fd4fe29220c81f6c653e841a2bf36aa58143562f055589a4450
+ARG BUF_VERSION=v0.31.1
+ARG BUF_CHECKSUM=ccc165280d09616e34b82fc408afb7fe6226201414c604ee76acc6f7b6d33380
 
 ARG BUFF_URL=https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64
 RUN apk --no-cache add --virtual .build curl \


### PR DESCRIPTION
Here is github.com/bufbuild/buf/releases v0.31.1, I hope it works.

<!--::action-update-go::
{"signed":{"name":"buf","updates":[{"path":"github.com/bufbuild/buf/releases","previous":"v0.31.0","next":"v0.31.1"}]},"signature":"gjZdPO0XQ/wMtaiDczrJAcqoh3qwZtaEj5+M9aqwvn8KKza2MWrfAG6J6PG7vxc2L4FJDjBYzPPwLEZqkqJunA=="}
-->