### PR TITLE
Update github.com/bufbuild/buf/releases from v0.32.0 to v0.32.1

### DIFF
--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.11 AS buf
 
-ARG BUF_VERSION=v0.32.0
-ARG BUF_CHECKSUM=f2d5de6c884e22fb8adc9b2a4ea82a8b92e4d2d994f8861708460df7fb595e59
+ARG BUF_VERSION=v0.32.1
+ARG BUF_CHECKSUM=8f4f3ff4b517f436f98e915812f00357724bca9bd601a36e6214584eb8b9d1ea
 
 ARG BUFF_URL=https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64
 RUN apk --no-cache add --virtual .build curl \


### PR DESCRIPTION
Here is github.com/bufbuild/buf/releases v0.32.1, I hope it works.

<!--::action-update-go::
{"signed":{"name":"buf","updates":[{"path":"github.com/bufbuild/buf/releases","previous":"v0.32.0","next":"v0.32.1"}]},"signature":"aW+cjR4wP32uZnlJzUcXwvrASGWTljj0f8v3dRFydQWCKVFJNyacGF4nTDx2j2R2s+krOCyJXSk3+H6t3jMkEg=="}
-->