### PR TITLE
Update github.com/bufbuild/buf/releases from v0.33.0 to v0.34.0

### DIFF
--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.11 AS buf
 
-ARG BUF_VERSION=v0.33.0
-ARG BUF_CHECKSUM=977930427bb6b962492586bb6d43c038bfb383dd82933ef28ebcb1a780263f9b
+ARG BUF_VERSION=v0.34.0
+ARG BUF_CHECKSUM=bc3a091f6901724b13e3cb8ff2c4df67617887cc14f3297b7b72d359c9568e01
 
 ARG BUFF_URL=https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64
 RUN apk --no-cache add --virtual .build curl \


### PR DESCRIPTION
Here is github.com/bufbuild/buf/releases v0.34.0, I hope it works.

<!--::action-update-go::
{"signed":{"name":"buf","updates":[{"path":"github.com/bufbuild/buf/releases","previous":"v0.33.0","next":"v0.34.0"}]},"signature":"+P51ESKKdVGCnpdVETu3ZcFgjlPYcPUYCzFT635TAVv5v8bg18XYxY/Gps3fOttUBICaZBYsHE8QTUJjTYN6aQ=="}
-->