### PR TITLE
Update github.com/bufbuild/buf/releases from v0.34.0 to v0.35.0

### DIFF
--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.11 AS buf
 
-ARG BUF_VERSION=v0.34.0
-ARG BUF_CHECKSUM=bc3a091f6901724b13e3cb8ff2c4df67617887cc14f3297b7b72d359c9568e01
+ARG BUF_VERSION=v0.35.0
+ARG BUF_CHECKSUM=41f9b7cd3521ca6ca14c84f34a37fa4951d8ac24e0bf81c4f47826caf39f7b69
 
 ARG BUFF_URL=https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64
 RUN apk --no-cache add --virtual .build curl \


### PR DESCRIPTION
Here is github.com/bufbuild/buf/releases v0.35.0, I hope it works.

<!--::action-update-go::
{"signed":{"name":"buf","updates":[{"path":"github.com/bufbuild/buf/releases","previous":"v0.34.0","next":"v0.35.0"}]},"signature":"/4k7qGADE6TzZE9jMnLcjimCOUArirBsnAfTvnWUftqi/NCZ3LstqJeTT4E1R47saUCWHaJt9V9VdfePcOIyNw=="}
-->