### PR TITLE
Update github.com/bufbuild/buf/releases from v0.35.0 to v0.35.1

### DIFF
--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.11 AS buf
 
-ARG BUF_VERSION=v0.35.0
-ARG BUF_CHECKSUM=41f9b7cd3521ca6ca14c84f34a37fa4951d8ac24e0bf81c4f47826caf39f7b69
+ARG BUF_VERSION=v0.35.1
+ARG BUF_CHECKSUM=b1986b786890562149cb1f341b1a089c80439844ca65391161397a8b0b9352a8
 
 ARG BUFF_URL=https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64
 RUN apk --no-cache add --virtual .build curl \


### PR DESCRIPTION
Here is github.com/bufbuild/buf/releases v0.35.1, I hope it works.

<!--::action-update-go::
{"signed":{"name":"buf","updates":[{"path":"github.com/bufbuild/buf/releases","previous":"v0.35.0","next":"v0.35.1"}]},"signature":"02W1KDyahviL7Oj1Mzr+gM1BUMaqDqkVG+xpa2xFM0F4d8b5scVS9mwUvj0GoKKw+poM04WhqLvx7jt7nAJ9SQ=="}
-->