### PR TITLE
Update github.com/bufbuild/buf/releases from v0.36.0 to v0.37.0

### DIFF
--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.11 AS buf
 
-ARG BUF_VERSION=v0.36.0
-ARG BUF_CHECKSUM=abbfd8e2986b33e02337252b556028f1e0f0aac54a7fed3f5969129a47a6dfd9
+ARG BUF_VERSION=v0.37.0
+ARG BUF_CHECKSUM=4868ea19370fd4b247fa9d1649e5516a1f755b50aa3046a782df8b7191c11271
 
 ARG BUFF_URL=https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64
 RUN apk --no-cache add --virtual .build curl \


### PR DESCRIPTION
Here is github.com/bufbuild/buf/releases v0.37.0, I hope it works.

<!--::action-update-go::
{"signed":{"name":"buf","updates":[{"path":"github.com/bufbuild/buf/releases","previous":"v0.36.0","next":"v0.37.0"}]},"signature":"H8YKM5prPoB7z/TDDCCz8yYMCXnXVAUeBILWPCiSVZwp1dDgPJfE4bz90jBuz+He3n1mzYKIYFPBadDUmJikqA=="}
-->