### PR TITLE
Update github.com/bufbuild/buf/releases from v0.39.1 to v0.40.0

### DIFF
--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.11 AS buf
 
-ARG BUF_VERSION=v0.39.1
-ARG BUF_CHECKSUM=ee88c142d5f608453e1c0b7fb274df143c60427244e9caef6256d2aa91b52b9b
+ARG BUF_VERSION=v0.40.0
+ARG BUF_CHECKSUM=ce9b0bea308970d6ac023ed9a6fb45e77647575ca4ff5b121df898243d60a519
 
 ARG BUFF_URL=https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64
 RUN apk --no-cache add --virtual .build curl \


### PR DESCRIPTION
Here is github.com/bufbuild/buf/releases v0.40.0, I hope it works.

<!--::action-update-go::
{"signed":{"name":"buf","updates":[{"path":"github.com/bufbuild/buf/releases","previous":"v0.39.1","next":"v0.40.0"}]},"signature":"YCZSZn3fJDcKqUnMygZC1gnjRB9UwfAg1S1AIV7CD/oPBWKwOcP7KNSWQBvwleEg5OUwNciB8Y8xoF3Af9izTw=="}
-->