### PR TITLE
Update golang from 1.13.8 to 1.16.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.8 AS builder
+FROM golang:1.16.2 AS builder
 
 RUN mkdir /app
 WORKDIR /app

--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -11,7 +11,7 @@ RUN apk --no-cache add --virtual .build curl \
   && apk del .build
 
 
-FROM golang:1.15.2 AS protoc-gen-go
+FROM golang:1.16.2 AS protoc-gen-go
 RUN mkdir /app
 WORKDIR /app
 COPY go.mod .


### PR DESCRIPTION
Here is golang 1.16.2, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"golang","previous":"1.13.8","next":"1.16.2"}]},"signature":"BjHW5mBQKlcY+e8JkrkLgeETtrDJg8daJv45PVGAiyKLHm4KFnKalqS1G75tSx0HiYZCobtCbFDV/H6i9NqzlA=="}
-->