### PR TITLE
Update golangci/golangci-lint from v1.31.0-alpine to v1.38.0-alpine

### DIFF
--- a/script/tools/golangci-lint/Dockerfile
+++ b/script/tools/golangci-lint/Dockerfile
@@ -1,3 +1,3 @@
-FROM golangci/golangci-lint:v1.31.0-alpine
+FROM golangci/golangci-lint:v1.38.0-alpine
 
 ENTRYPOINT ["/usr/bin/golangci-lint","run"]


### PR DESCRIPTION
Here is golangci/golangci-lint v1.38.0-alpine, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"golangci/golangci-lint","previous":"v1.31.0-alpine","next":"v1.38.0-alpine"}]},"signature":"+TOnqh1eRvAcKQQh0YlI3L2tmiZLs27Ssr5Bfd7V5nhTuWCVU4Wz3IfaCFZg+6FBDchwZXYP6IN1V8TmwtTJ9A=="}
-->