### PR TITLE
Update golang from 1.16.2 to 1.16.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.2 AS builder
+FROM golang:1.16.3 AS builder
 
 RUN mkdir /app
 WORKDIR /app

--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -11,7 +11,7 @@ RUN apk --no-cache add --virtual .build curl \
   && apk del .build
 
 
-FROM golang:1.16.2 AS protoc-gen-go
+FROM golang:1.16.3 AS protoc-gen-go
 RUN mkdir /app
 WORKDIR /app
 COPY go.mod .


### PR DESCRIPTION
Here is golang 1.16.3, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"golang","previous":"1.16.2","next":"1.16.3"}]},"signature":"svt3rKnJ8OhW6H6l6/pLR2yFDhW4tPmwZ44mhtzhWfa1HyQkranXlWLkDjc+Yr4j+LgjXRkr7HBrLAeH2GmKDg=="}
-->