### PR TITLE
Update golangci/golangci-lint from v1.39.0-alpine to v1.40.0-alpine

### DIFF
--- a/script/tools/golangci-lint/Dockerfile
+++ b/script/tools/golangci-lint/Dockerfile
@@ -1,3 +1,3 @@
-FROM golangci/golangci-lint:v1.39.0-alpine
+FROM golangci/golangci-lint:v1.40.0-alpine
 
 ENTRYPOINT ["/usr/bin/golangci-lint","run"]


### PR DESCRIPTION
Here is golangci/golangci-lint v1.40.0-alpine, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"golangci/golangci-lint","previous":"v1.39.0-alpine","next":"v1.40.0-alpine"}]},"signature":"fjeKKhma6TP9QAouXq8vJEBF4dlp6IdDkafZpjk0DfGcPorNdN/ERqwtV82WA/zIhYaRObpHOLNRX/POMkqrkQ=="}
-->