### PR TITLE
Update golang from 1.16.4 to 1.16.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.4 AS builder
+FROM golang:1.16.5 AS builder
 
 RUN mkdir /app
 WORKDIR /app

--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -11,7 +11,7 @@ RUN apk --no-cache add --virtual .build curl \
   && apk del .build
 
 
-FROM golang:1.16.4 AS protoc-gen-go
+FROM golang:1.16.5 AS protoc-gen-go
 RUN mkdir /app
 WORKDIR /app
 COPY go.mod .


### PR DESCRIPTION
Here is golang 1.16.5, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"golang","previous":"1.16.4","next":"1.16.5"}]},"signature":"E6xVVCyiBX5cJQIdpGcg7OKBeBZsnufq/egpgljrGorgrfiWWKZyesmCVe40o/DrjtjhhmJ7vXmyUlbush+hWg=="}
-->