### PR TITLE
Update golangci/golangci-lint from v1.40.1-alpine to v1.41.0-alpine

### DIFF
--- a/script/tools/golangci-lint/Dockerfile
+++ b/script/tools/golangci-lint/Dockerfile
@@ -1,3 +1,3 @@
-FROM golangci/golangci-lint:v1.40.1-alpine
+FROM golangci/golangci-lint:v1.41.0-alpine
 
 ENTRYPOINT ["/usr/bin/golangci-lint","run"]


### PR DESCRIPTION
Here is golangci/golangci-lint v1.41.0-alpine, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"golangci/golangci-lint","previous":"v1.40.1-alpine","next":"v1.41.0-alpine"}]},"signature":"I/vq4XAQ0I8gmKLW5zVBsC7a4D0HG97ExXaBsG+Sf7yFS2PqcCNanQi28OeGfrZ7nkeuFiyfetLlbloopdMcFw=="}
-->