### PR TITLE
Update golang from 1.16.5 to 1.16.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.5 AS builder
+FROM golang:1.16.6 AS builder
 
 RUN mkdir /app
 WORKDIR /app

--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -11,7 +11,7 @@ RUN apk --no-cache add --virtual .build curl \
   && apk del .build
 
 
-FROM golang:1.16.5 AS protoc-gen-go
+FROM golang:1.16.6 AS protoc-gen-go
 RUN mkdir /app
 WORKDIR /app
 COPY go.mod .


### PR DESCRIPTION
Here is golang 1.16.6, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"golang","previous":"1.16.5","next":"1.16.6"}]},"signature":"UbLysw0YiKyjpZhhLRTZkFhfuhdAcba4I7Km49vI0owfim9p1NIqD6rcA3GwByyGnyzHCiFsVCWO4xRhy9KCIA=="}
-->