### PR TITLE
Update github.com/bufbuild/buf/releases from v0.45.0 to v0.46.0

### DIFF
--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.14.0 AS buf
 
-ARG BUF_VERSION=v0.45.0
-ARG BUF_CHECKSUM=4beba8f60d9d9b2ab6e34c1d4580d2147d3b3c33e01bb643a0e587b5efc45bc4
+ARG BUF_VERSION=v0.46.0
+ARG BUF_CHECKSUM=01eea0b169bd128b3c78d0d2740667e52a0da1f9ebd4774b21316248d78e2953
 
 ARG BUFF_URL=https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64
 RUN apk --no-cache add --virtual .build curl \


### PR DESCRIPTION
Here is github.com/bufbuild/buf/releases v0.46.0, I hope it works.

<!--::action-update-go::
{"signed":{"name":"buf","updates":[{"path":"github.com/bufbuild/buf/releases","previous":"v0.45.0","next":"v0.46.0"}]},"signature":"ppwph6HlLvVszl+IrLYlRGnsDqzczKKxtAe2k1JgLcHPkwCvjxGffygpT01zq4yf7ngLNXsfRvr9TfGETjvJsQ=="}
-->