### PR TITLE
Update github.com/bufbuild/buf/releases from v0.46.0 to v0.48.0

### DIFF
--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.14.0 AS buf
 
-ARG BUF_VERSION=v0.46.0
-ARG BUF_CHECKSUM=01eea0b169bd128b3c78d0d2740667e52a0da1f9ebd4774b21316248d78e2953
+ARG BUF_VERSION=v0.48.0
+ARG BUF_CHECKSUM=444005e5ccb621951150e1740feab5bb6d7015038006ca7cc5f076811df9dd93
 
 ARG BUFF_URL=https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64
 RUN apk --no-cache add --virtual .build curl \


### PR DESCRIPTION
Here is github.com/bufbuild/buf/releases v0.48.0, I hope it works.

<!--::action-update-go::
{"signed":{"name":"buf","updates":[{"path":"github.com/bufbuild/buf/releases","previous":"v0.46.0","next":"v0.48.0"}]},"signature":"ruEXieHLD/mfbPEch97YV0JOds29TSkC0nh52FAoivWZGqk1n9iIvk9YbZWlk6fYQjRe5DkvztEaUWtb0TAisA=="}
-->