### PR TITLE
Update github.com/bufbuild/buf/releases from v0.48.0 to v0.48.2

### DIFF
--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.14.0 AS buf
 
-ARG BUF_VERSION=v0.48.0
-ARG BUF_CHECKSUM=444005e5ccb621951150e1740feab5bb6d7015038006ca7cc5f076811df9dd93
+ARG BUF_VERSION=v0.48.2
+ARG BUF_CHECKSUM=c64901dfaa9d7dd5ffa9260e2a0c08dec9d2df7a142e617be388b55ff0176d6f
 
 ARG BUFF_URL=https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64
 RUN apk --no-cache add --virtual .build curl \


### PR DESCRIPTION
Here is github.com/bufbuild/buf/releases v0.48.2, I hope it works.

<!--::action-update-go::
{"signed":{"name":"buf","updates":[{"path":"github.com/bufbuild/buf/releases","previous":"v0.48.0","next":"v0.48.2"}]},"signature":"RAOb3KVUhGopxgfSSlO6ZSngcFVhqlt33w5OP3dfdIkQAT/R2kGISq97xoRh2kAC1IUCiMOTrKB/x3X+JSz6mg=="}
-->