### PR TITLE
Update golang from 1.16.6 to 1.16.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.6 AS builder
+FROM golang:1.16.7 AS builder
 
 RUN mkdir /app
 WORKDIR /app

--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -11,7 +11,7 @@ RUN apk --no-cache add --virtual .build curl \
   && apk del .build
 
 
-FROM golang:1.16.6 AS protoc-gen-go
+FROM golang:1.16.7 AS protoc-gen-go
 RUN mkdir /app
 WORKDIR /app
 COPY go.mod .


### PR DESCRIPTION
Here is golang 1.16.7, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"golang","previous":"1.16.6","next":"1.16.7"}]},"signature":"LLfDfTZqrR+0L2k3XTSj+uqhsuiaNu0jpdlOQ9lzXErXLNvhAjfkq+5pJO9yrBWwQzCSO40hL6/10p2oymHhEA=="}
-->