### PR TITLE
Verify buf

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 /coverage.out
 /Dockerfile
 /index.pb
+/script

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY . .
 ARG CGO_ENABLED=0
 RUN go build -o /archivist .
 
-FROM alpine:3.14.1@sha256:eb3e4e175ba6d212ba1d6e04fc0782916c08e1c9d7b45892e9796141b1d379ae
-COPY --from=builder /archivist /usr/local/bin
-ENTRYPOINT ["/usr/local/bin/archivist"]
+FROM scratch
+COPY go.sum /go.sum
+COPY --from=builder /archivist /archivist
+ENTRYPOINT ["/archivist"]

--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -4,13 +4,20 @@ FROM alpine:3.14.1@sha256:eb3e4e175ba6d212ba1d6e04fc0782916c08e1c9d7b45892e97961
 ARG BUF_VERSION=v0.52.0
 ARG BUF_CHECKSUM=dfa0e0d5c4784b2f8e34402b1c427ce71822d6dfaa55d1bce919bc33e4dee488
 
+ARG BUF_MINISIGN_KEY=RWQ/i9xseZwBVE7pEniCNjlNOeeyp4BQgdZDLQcAohxEAH5Uj5DEKjv6
 ARG BUFF_URL=https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64
-RUN apk --no-cache add --virtual .build curl \
+ARG BUFF_DIGESTS_URL=https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/sha256.txt
+RUN apk --no-cache add curl \
+  && apk --no-cached --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing add minisign \
+  && mkdir -p /buf \
+  && curl -Lo /buf/sha256.txt "$BUFF_DIGESTS_URL" \
+  && curl -Lo /buf/sha256.txt.minisig "$BUFF_DIGESTS_URL.minisig" \
+  && minisign -Vm /buf/sha256.txt -P "$BUF_MINISIGN_KEY" \
+  && grep -q "$BUF_CHECKSUM" /buf/sha256.txt \
   && curl -o /usr/local/bin/buf -L "$BUFF_URL" \
   && echo "$BUF_CHECKSUM  /usr/local/bin/buf" | sha256sum -c \
   && chmod +x /usr/local/bin/buf \
-  && apk del .build
-
+  && apk del curl minisign
 
 FROM golang:1.17.0@sha256:634cda4edda00e59167e944cdef546e2d62da71ef1809387093a377ae3404df0 AS protoc-gen-go
 RUN mkdir /app


### PR DESCRIPTION
Modify the `script/tools/buf/Dockerfile` helper to verify the `buf` binary with the signatures provided by https://github.com/bufbuild/buf/issues/442

This reinforces `BUF_CHECKSUM`: instead of being a checksum that Renovate ✨somehow✨ identifies, the checksum is verified to be in the signed checksum file released upstream.

Since the key is pinned, pinning `BUF_CHECKSUM` is overkill.